### PR TITLE
Do not split Integer with future parser

### DIFF
--- a/templates/haproxy_balancermember.erb
+++ b/templates/haproxy_balancermember.erb
@@ -1,3 +1,3 @@
 <% Array(@ipaddresses).zip(Array(@server_names)).each do |ipaddress,host| -%>
-  server <%= host %> <%= ipaddress %>:<%= Array(@ports).collect {|x|x.split(',')}.flatten.join(",#{ipaddress}:") %> <%= if @define_cookies then "cookie " + host end %> <%= Array(@options).join(" ") %>
+  server <%= host %> <%= ipaddress %>:<%= Array(@ports).flatten.join(",#{ipaddress}:") %> <%= if @define_cookies then "cookie " + host end %> <%= Array(@options).join(" ") %>
 <% end -%>


### PR DESCRIPTION
This PR is used to ensure that strings are no longer attempted to be split, given we're taking integers and arrays from here on out.

